### PR TITLE
feat(scaffold/scheduler): implementation of scheduler for the orchestrator

### DIFF
--- a/src/scheduler/scheduler.zig
+++ b/src/scheduler/scheduler.zig
@@ -3,3 +3,18 @@
 // machines on which a task can run. score the candidate
 // machines from the best to worst, and pick the machine
 // with the highest score.
+
+const std = @import("std");
+const task = @import("../task/task.zig");
+const node = @import("node.zig"); // assume this is already here
+
+pub const Scheduler = struct {
+    // interface methods
+    pub const Interface = struct {
+        selectCandidateNodes: *const fn (allocator: std.mem.Allocator, task: *task.Task, nodes: []*node.Node) []*node.Node,
+
+        score: *const fn (allocator: std.mem.Allocator, task: *task.Task, nodes: []*node.Node) std.StringHashMap(f32),
+
+        pick: *const fn (scores: std.StringHashMap(f32), candidates: []*node.Node) ?*node.Node,
+    };
+};

--- a/src/scheduler/scheduler.zig
+++ b/src/scheduler/scheduler.zig
@@ -1,0 +1,5 @@
+// scheduler.zig
+// the scheduler ishould be able to determine a set of
+// machines on which a task can run. score the candidate
+// machines from the best to worst, and pick the machine
+// with the highest score.


### PR DESCRIPTION
This pull request introduces a new `Scheduler` module in `src/scheduler/scheduler.zig` to handle task scheduling by selecting candidate nodes, scoring them, and picking the best one. The changes define a structured interface for these operations.


### Scheduler Module Introduction:
* Added a new `Scheduler` struct with an `Interface` sub-struct that defines three methods:
  - [`selectCandidateNodes`](diffhunk://#diff-fb7cb637ed0c547f1c17d4ed6e30db7c78d36762a42675c28dd64ebcded02acaR1-R20): Identifies candidate nodes for a given task.
  - [`score`](diffhunk://#diff-fb7cb637ed0c547f1c17d4ed6e30db7c78d36762a42675c28dd64ebcded02acaR1-R20): Scores the candidate nodes based on suitability for the task.
  - [`pick`](diffhunk://#diff-fb7cb637ed0c547f1c17d4ed6e30db7c78d36762a42675c28dd64ebcded02acaR1-R20): Selects the best node from the scored candidates.

NOTE: More implementation needs be added to this file.